### PR TITLE
feat: implement feed/post update subscriptions

### DIFF
--- a/server/src/graphql/schema.gen.json
+++ b/server/src/graphql/schema.gen.json
@@ -1295,6 +1295,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "postFeedUpdates",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PostWithLikeCount",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postUpdates",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PostWithLikeCount",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -48,6 +48,8 @@ type Mutation {
 
 type Subscription {
   surveyUpdates (surveyId: Int!): Survey
+  postFeedUpdates: PostWithLikeCount
+  postUpdates: PostWithLikeCount
 }
 
 type User {

--- a/server/src/graphql/schema.types.ts
+++ b/server/src/graphql/schema.types.ts
@@ -80,6 +80,8 @@ export interface MutationFollowUserArgs {
 export interface Subscription {
   __typename?: 'Subscription'
   surveyUpdates?: Maybe<Survey>
+  postFeedUpdates?: Maybe<PostWithLikeCount>
+  postUpdates?: Maybe<PostWithLikeCount>
 }
 
 export interface SubscriptionSurveyUpdatesArgs {
@@ -424,6 +426,13 @@ export type SubscriptionResolvers<
     ContextType,
     RequireFields<SubscriptionSurveyUpdatesArgs, 'surveyId'>
   >
+  postFeedUpdates?: SubscriptionResolver<
+    Maybe<ResolversTypes['PostWithLikeCount']>,
+    'postFeedUpdates',
+    ParentType,
+    ContextType
+  >
+  postUpdates?: SubscriptionResolver<Maybe<ResolversTypes['PostWithLikeCount']>, 'postUpdates', ParentType, ContextType>
 }
 
 export type UserResolvers<

--- a/web/src/graphql/query.gen.ts
+++ b/web/src/graphql/query.gen.ts
@@ -161,6 +161,36 @@ export interface FetchPostDetailsVariables {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL subscription operation: PostFeedSubscription
+// ====================================================
+
+export interface PostFeedSubscription_postUpdates_user {
+  __typename: "User";
+  id: number;
+  name: string;
+  email: string;
+  userType: UserType;
+}
+
+export interface PostFeedSubscription_postUpdates {
+  __typename: "PostWithLikeCount";
+  id: number;
+  musicLink: string;
+  commentary: string | null;
+  likes: number;
+  user: PostFeedSubscription_postUpdates_user | null;
+}
+
+export interface PostFeedSubscription {
+  postUpdates: PostFeedSubscription_postUpdates | null;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: FetchSurveys
 // ====================================================
 

--- a/web/src/view/page/Post.tsx
+++ b/web/src/view/page/Post.tsx
@@ -65,11 +65,14 @@ export function Post(props: { postData: PostWithLikeCount }) {
     return (
       <div>
         <h3>WE ARE DISPLAYING THE COMMENTS</h3>
-        {comments.map((cmnt, i) => (
-          cmnt && (<h2 key={i}>
-            {cmnt.user?.name || 'anon'}: {cmnt.text}
-          </h2>)
-        ))}
+        {comments.map(
+          (cmnt, i) =>
+            cmnt && (
+              <h2 key={i}>
+                {cmnt.user?.name || 'anon'}: {cmnt.text}
+              </h2>
+            )
+        )}
         {comments &&
           (commentData?.postDetails?.commentFeed?.hasMore || staleComments) &&
           (loadingComments ? <div> Loading comments... </div> : <Button onClick={fetchMoreComments}>Load More</Button>)}

--- a/web/src/view/playground/fetchPost.ts
+++ b/web/src/view/playground/fetchPost.ts
@@ -70,6 +70,25 @@ const fetchPostCommentsQuery = gql`
   ${fragmentComment}
 `
 
+export const postFeedSubscription = gql`
+  subscription PostFeedSubscription {
+    postFeedUpdates {
+      ...PostWithLikeCount
+    }
+  }
+  ${fragmentPostWithLikeCount}
+  ${fragmentUser}
+`
+
+export const postUpdatesSubscription = gql`
+  subscription PostUpdatesSubscription {
+    postUpdates {
+      id
+      likes
+    }
+  }
+`
+
 export function fetchPosts($cursor?: string) {
   return useQuery<FetchPosts>(fetchPostQuery, { variables: { cursor: $cursor } })
 }


### PR DESCRIPTION
New posts are now immediately updated on feed page with subscriptions

Updates (e.g. likes) to posts are also immediately updated with subscriptions